### PR TITLE
fix: handle case where failure test is empty and message is in attribute

### DIFF
--- a/src/junit.rs
+++ b/src/junit.rs
@@ -96,6 +96,9 @@ pub fn parse_junit_xml(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
                     let mut testrun = saved_testrun
                         .ok_or(ParserError::new_err("Error accessing saved testrun"))?;
                     testrun.outcome = Outcome::Failure;
+                    let attr_hm = attributes_map(e.attributes())?;
+                    let tentative_message = attr_hm.get("message").cloned();
+                    testrun.failure_message = tentative_message;
                     saved_testrun = Some(testrun);
                     in_failure = true;
                 }

--- a/tests/empty_failure.junit.xml
+++ b/tests/empty_failure.junit.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites tests="2" failures="1" errors="0" skipped="0" time="1.234">
+    <testsuite name="test" tests="2" errors="0" failures="0" skipped="0" time="1.234">
+        <testcase classname="test.test"
+            name="test.test works"
+            file="./test.rb" time="0.234" />
+    </testsuite>
+    <testcase classname="test.test"
+        name="test.test fails"
+        file="./test.rb" time="1.000">
+        <failure message="TestError"
+            type="TestError">
+</failure>
+    </testcase>
+</testsuites>

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -93,6 +93,25 @@ tests/test_parsers.py:16: AssertionError""",
                     ),
                 ],
             ),
+            (
+                "./tests/empty_failure.junit.xml",
+                [
+                    Testrun(
+                        "test.test::test.test works",
+                        0.234,
+                        Outcome.Pass,
+                        "test",
+                        None
+                    ),
+                    Testrun(    
+                        "test.test::test.test fails",
+                        1,
+                        Outcome.Failure,
+                        "test",
+                        "TestError"
+                    ),
+                ]
+            ),
         ],
     )
     def test_junit(self, filename, expected):
@@ -101,3 +120,4 @@ tests/test_parsers.py:16: AssertionError""",
             assert len(res) == len(expected)
             for restest, extest in zip(res, expected):
                 assert restest == extest
+


### PR DESCRIPTION
There are some JUnit XML files that will leave the text empty for failures and include the message as an attribute on the failure element. This PR handles that case.