### PR TITLE
feat: add failure message manipulation functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}
           url: ${{ secrets.CODECOV_URL }}
           file: unit.junit.xml
+          disable_search: true
+
 
       - name: Upload results to codecov
         if: ${{ !cancelled() }}
@@ -46,3 +48,4 @@ jobs:
           token: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
           url: ${{ secrets.CODECOV_STAGING_API_URL }}
           file: unit.junit.xml
+          disable_search: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}
           url: ${{ secrets.CODECOV_URL }}
+          file: unit.junit.xml
 
       - name: Upload results to codecov
         if: ${{ !cancelled() }}
@@ -44,3 +45,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
           url: ${{ secrets.CODECOV_STAGING_API_URL }}
+          file: unit.junit.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,16 +30,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "indoc"
-version = "1.0.9"
+name = "either"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -93,6 +129,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
+checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -120,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
+checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -130,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
+checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -140,25 +218,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
+checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
+checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -180,6 +259,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +281,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "ryu"
@@ -217,7 +340,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -232,21 +355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -269,8 +387,12 @@ checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 name = "test_results_parser"
 version = "0.1.0"
 dependencies = [
+ "itertools",
+ "lazy_static",
+ "phf",
  "pyo3",
  "quick-xml",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -283,9 +405,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ name = "test_results_parser"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.19.0"
+itertools = "0.12.1"
+lazy_static = "1.4.0"
+phf = { version = "0.11.2", features = ["macros"] }
+pyo3 = "0.20.1"
 quick-xml = "0.31.0"
+regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use phf::phf_ordered_map;
 
-use pyo3::prelude::*;
+use pyo3::{ffi::PySys_ResetWarnOptions, prelude::*, types::PyString};
 
 use itertools::Itertools;
 use regex::Regex;
@@ -13,37 +13,85 @@ static REPLACEMENTS: phf::OrderedMap<&'static str, &'static str> = phf_ordered_m
     "'" => "&apos;",
     "<" => "&lt;",
     ">" => "&gt;",
-    "?" => "&amp;",
+    "&" => "&amp;",
     "\r" =>  "",
     "\n" =>  "<br>",
 };
 
 #[pyfunction]
-pub fn escape_failure_message(mut failure_message: String) -> String {
+pub fn escape_failure_message_pystring<'py>(
+    py: Python<'py>,
+    failure_message: &PyString,
+) -> &'py PyString {
+    let mut escaped_failure_message = failure_message.to_string();
     for (from, to) in REPLACEMENTS.entries() {
-        failure_message = failure_message.replace(from, to);
+        escaped_failure_message = escaped_failure_message.replace(from, to);
     }
-    failure_message
+    &PyString::new(py, &escaped_failure_message)
 }
 
+#[pyfunction]
+pub fn escape_failure_message_rust_string(failure_message: String) -> String {
+    let mut escaped_failure_message = failure_message.clone();
+    for (from, to) in REPLACEMENTS.entries() {
+        escaped_failure_message = escaped_failure_message.replace(from, to);
+    }
+    escaped_failure_message
+}
+
+/*
+Examples of strings that match:
+
+/path/to/file.txt
+/path/to/file
+/path/to
+path/to:1:2
+/path/to/file.txt:1:2
+
+Examples of strings that don't match:
+
+path
+file.txt
+*/
 lazy_static! {
     static ref SHORTEN_PATH_PATTERN: Regex =
         Regex::new(r"(?:\/*[\w\-]+\/)+(?:[\w\.]+)(?::\d+:\d+)*").unwrap();
 }
 
 #[pyfunction]
-pub fn shorten_file_paths(mut failure_message: String) -> String {
-    let original_failure_message = failure_message.clone();
-    for m in SHORTEN_PATH_PATTERN.find_iter(&original_failure_message) {
+pub fn shorten_file_paths_rust_string(failure_message: String) -> String {
+    let mut resulting_string = failure_message.clone();
+    for m in SHORTEN_PATH_PATTERN.find_iter(&failure_message) {
         let filepath = m.as_str();
         let split_file_path: Vec<_> = filepath.split("/").collect();
 
         if split_file_path.len() > 3 {
-            let mut slice = split_file_path.iter().rev().take(3);
+            let mut slice = split_file_path.iter().rev().take(3).rev();
 
             let s = format!("{}{}", ".../", slice.join("/"));
-            failure_message = failure_message.replace(filepath, &s);
+            resulting_string = resulting_string.replace(filepath, &s);
         }
     }
-    failure_message
+    resulting_string
+}
+
+#[pyfunction]
+pub fn shorten_file_paths_pystring<'py>(
+    py: Python<'py>,
+    python_failure_message: &PyString,
+) -> &'py PyString {
+    let string_to_read_from = python_failure_message.to_string_lossy();
+    let mut resulting_string = python_failure_message.to_string_lossy().into_owned();
+    for m in SHORTEN_PATH_PATTERN.find_iter(&string_to_read_from) {
+        let filepath = m.as_str();
+        let split_file_path: Vec<_> = filepath.split("/").collect();
+
+        if split_file_path.len() > 3 {
+            let mut slice = split_file_path.iter().rev().take(3).rev();
+
+            let s = format!("{}{}", ".../", slice.join("/"));
+            resulting_string = resulting_string.replace(filepath, &s);
+        }
+    }
+    &PyString::new(py, &resulting_string)
 }

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -84,14 +84,14 @@ fn generate_failure_info(failure_message: &Option<String>) -> String {
     }
 }
 
-#[derive(FromPyObject)]
-struct Failure {
+#[derive(FromPyObject, Debug)]
+pub struct Failure {
     name: String,
     testsuite: String,
     failure_message: Option<String>,
 }
-#[derive(FromPyObject)]
-struct MessagePayload {
+#[derive(FromPyObject, Debug)]
+pub struct MessagePayload {
     passed: i32,
     failed: i32,
     skipped: i32,

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -86,22 +86,15 @@ fn generate_failure_info(failure_message: &Option<String>) -> String {
 
 #[derive(FromPyObject)]
 struct Failure {
-    #[pyo3(attribute("name"))]
     name: String,
-    #[pyo3(attribute("testsuite"))]
     testsuite: String,
-    #[pyo3(attribute("failure_message"))]
     failure_message: Option<String>,
 }
 #[derive(FromPyObject)]
 struct MessagePayload {
-    #[pyo3(attribute("passed"))]
     passed: i32,
-    #[pyo3(attribute("failed"))]
     failed: i32,
-    #[pyo3(attribute("skipped"))]
     skipped: i32,
-    #[pyo3(attribute("failures"))]
     failures: Vec<Failure>,
 }
 

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -1,0 +1,49 @@
+use lazy_static::lazy_static;
+use phf::phf_ordered_map;
+
+use pyo3::prelude::*;
+
+use itertools::Itertools;
+use regex::Regex;
+
+// Need to use an ordered map to make sure we replace '>' before
+// we replace '\n', so that we don't replace the '>' in '<br>'
+static REPLACEMENTS: phf::OrderedMap<&'static str, &'static str> = phf_ordered_map! {
+    "\"" => "&quot;",
+    "'" => "&apos;",
+    "<" => "&lt;",
+    ">" => "&gt;",
+    "?" => "&amp;",
+    "\r" =>  "",
+    "\n" =>  "<br>",
+};
+
+#[pyfunction]
+pub fn escape_failure_message(mut failure_message: String) -> String {
+    for (from, to) in REPLACEMENTS.entries() {
+        failure_message = failure_message.replace(from, to);
+    }
+    failure_message
+}
+
+lazy_static! {
+    static ref SHORTEN_PATH_PATTERN: Regex =
+        Regex::new(r"(?:\/*[\w\-]+\/)+(?:[\w\.]+)(?::\d+:\d+)*").unwrap();
+}
+
+#[pyfunction]
+pub fn shorten_file_paths(mut failure_message: String) -> String {
+    let original_failure_message = failure_message.clone();
+    for m in SHORTEN_PATH_PATTERN.find_iter(&original_failure_message) {
+        let filepath = m.as_str();
+        let split_file_path: Vec<_> = filepath.split("/").collect();
+
+        if split_file_path.len() > 3 {
+            let mut slice = split_file_path.iter().rev().take(3);
+
+            let s = format!("{}{}", ".../", slice.join("/"));
+            failure_message = failure_message.replace(filepath, &s);
+        }
+    }
+    failure_message
+}

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -5,7 +5,7 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use std::collections::HashMap;
 
-use crate::helpers::{s, ParserError};
+use crate::helpers::ParserError;
 use crate::testrun::{Outcome, Testrun};
 
 // from https://gist.github.com/scott-codecov/311c174ecc7de87f7d7c50371c6ef927#file-cobertura-rs-L18-L31

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 
+mod failure_message;
 mod helpers;
 mod junit;
 mod pytest_reportlog;
@@ -19,6 +20,11 @@ fn test_results_parser(_py: Python, m: &PyModule) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(vitest_json::parse_vitest_json, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        failure_message::escape_failure_message,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(failure_message::shorten_file_paths, m)?)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,21 @@ fn test_results_parser(_py: Python, m: &PyModule) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(vitest_json::parse_vitest_json, m)?)?;
     m.add_function(wrap_pyfunction!(
-        failure_message::escape_failure_message,
+        failure_message::escape_failure_message_pystring,
         m
     )?)?;
-    m.add_function(wrap_pyfunction!(failure_message::shorten_file_paths, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        failure_message::escape_failure_message_rust_string,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        failure_message::shorten_file_paths_pystring,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        failure_message::shorten_file_paths_rust_string,
+        m
+    )?)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,22 +20,12 @@ fn test_results_parser(_py: Python, m: &PyModule) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(vitest_json::parse_vitest_json, m)?)?;
+    m.add_function(wrap_pyfunction!(failure_message::build_message, m)?)?;
     m.add_function(wrap_pyfunction!(
-        failure_message::escape_failure_message_pystring,
+        failure_message::escape_failure_message,
         m
     )?)?;
-    m.add_function(wrap_pyfunction!(
-        failure_message::escape_failure_message_rust_string,
-        m
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        failure_message::shorten_file_paths_pystring,
-        m
-    )?)?;
-    m.add_function(wrap_pyfunction!(
-        failure_message::shorten_file_paths_rust_string,
-        m
-    )?)?;
+    m.add_function(wrap_pyfunction!(failure_message::shorten_file_paths, m)?)?;
 
     Ok(())
 }

--- a/src/vitest_json.rs
+++ b/src/vitest_json.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::{s, ParserError};
+use crate::helpers::ParserError;
 use crate::testrun::{Outcome, Testrun};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -1,16 +1,16 @@
-from test_results_parser import escape_failure_message, shorten_file_paths
+import pytest 
+from test_results_parser import escape_failure_message_pystring, shorten_file_paths_pystring, escape_failure_message_rust_string, shorten_file_paths_rust_string
 
-
-def test_escape_failure_message():
+@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
+def test_escape_failure_message(escape_failure_message):
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
     res = escape_failure_message(failure_message)
 
-    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&lt;anonymous&gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&lt;anonymous&gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""
+    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&amp;lt;anonymous&amp;gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&amp;lt;anonymous&amp;gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""
 
-
-
-def test_shorten_file_paths():
+@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
+def test_shorten_file_paths(shorten_file_paths):
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
 
@@ -21,35 +21,67 @@ def test_shorten_file_paths():
 Expected: 4
 Received: 5
 at Object.&lt;anonymous&gt;
-(.../calculator.test.ts:5:26/calculator/demo)
+(.../demo/calculator/calculator.test.ts:5:26)
 at Promise.then.completed
-(.../utils.js:298:28/build/jest-circus)
+(.../jest-circus/build/utils.js:298:28)
 at new Promise (&lt;anonymous&gt;)
 at callAsyncCircusFn
-(.../utils.js:231:10/build/jest-circus)
+(.../jest-circus/build/utils.js:231:10)
 at _callCircusTest
-(.../run.js:316:40/build/jest-circus)
+(.../jest-circus/build/run.js:316:40)
 at processTicksAndRejections (node:internal/process/task_queues:95:5)
 at _runTest
-(.../run.js:252:3/build/jest-circus)
+(.../jest-circus/build/run.js:252:3)
 at _runTestsForDescribeBlock
-(.../run.js:126:9/build/jest-circus)
+(.../jest-circus/build/run.js:126:9)
 at run
-(.../run.js:71:3/build/jest-circus)
+(.../jest-circus/build/run.js:71:3)
 at runAndTransformResultsToJestFormat
-(.../jestAdapterInit.js:122:21/legacy-code-todo-rewrite/build)
+(.../build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
 at jestAdapter
-(.../jestAdapter.js:79:19/legacy-code-todo-rewrite/build)
+(.../build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
 at runTestInternal
-(.../runTest.js:367:16/build/jest-runner)
+(.../jest-runner/build/runTest.js:367:16)
 at runTest
-(.../runTest.js:444:34/build/jest-runner)"""
+(.../jest-runner/build/runTest.js:444:34)"""
 
-def test_both():
+@pytest.mark.parametrize("shorten_file_paths,escape_failure_message", [(shorten_file_paths_pystring, escape_failure_message_pystring),(shorten_file_paths_rust_string, escape_failure_message_rust_string)])
+def test_shorten_and_escape_failure_message(shorten_file_paths, escape_failure_message):
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
 
     partial_res = shorten_file_paths(failure_message)
-    res = escape_failure_message(failure_message)
+    res = escape_failure_message(partial_res)
    
-    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&lt;anonymous&gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&lt;anonymous&gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""
+    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&amp;lt;anonymous&amp;gt;<br>(.../demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(.../jest-circus/build/utils.js:298:28)<br>at new Promise (&amp;lt;anonymous&amp;gt;)<br>at callAsyncCircusFn<br>(.../jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(.../jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(.../jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(.../jest-circus/build/run.js:126:9)<br>at run<br>(.../jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(.../build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(.../build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(.../jest-runner/build/runTest.js:367:16)<br>at runTest<br>(.../jest-runner/build/runTest.js:444:34)"""
+
+
+@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
+def test_escape_failure_message_happy_path(escape_failure_message):
+    failure_message = "\"'<>&\r\n"
+    res = escape_failure_message(failure_message)
+    assert res == "&amp;quot;&amp;apos;&amp;lt;&amp;gt;&amp;<br>"
+
+@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
+def test_escape_failure_message_slash_in_message(escape_failure_message):
+    failure_message = "\\ \\n \n"
+    res = escape_failure_message(failure_message)
+    assert res == "\\ \\n <br>"
+
+@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
+def test_shorten_file_paths_short_path(shorten_file_paths):
+    failure_message = "short/file/path.txt"
+    res = shorten_file_paths(failure_message)
+    assert res == failure_message
+
+@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
+def test_shorten_file_paths_long_path(shorten_file_paths):
+    failure_message = "very/long/file/path/should/be/shortened.txt"
+    res = shorten_file_paths(failure_message)
+    assert res == ".../should/be/shortened.txt"
+
+@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
+def test_shorten_file_paths_long_path_leading_slash(shorten_file_paths):
+    failure_message = "/very/long/file/path/should/be/shortened.txt"
+    res = shorten_file_paths(failure_message)
+    assert res == ".../should/be/shortened.txt"

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -1,16 +1,14 @@
-import pytest 
-from test_results_parser import escape_failure_message_pystring, shorten_file_paths_pystring, escape_failure_message_rust_string, shorten_file_paths_rust_string
+from dataclasses import dataclass
+from test_results_parser import escape_failure_message, shorten_file_paths, build_message
 
-@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
-def test_escape_failure_message(escape_failure_message):
+def test_escape_failure_message():
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
     res = escape_failure_message(failure_message)
 
     assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&amp;lt;anonymous&amp;gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&amp;lt;anonymous&amp;gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""
 
-@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
-def test_shorten_file_paths(shorten_file_paths):
+def test_shorten_file_paths():
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
 
@@ -45,8 +43,7 @@ at runTestInternal
 at runTest
 (.../jest-runner/build/runTest.js:444:34)"""
 
-@pytest.mark.parametrize("shorten_file_paths,escape_failure_message", [(shorten_file_paths_pystring, escape_failure_message_pystring),(shorten_file_paths_rust_string, escape_failure_message_rust_string)])
-def test_shorten_and_escape_failure_message(shorten_file_paths, escape_failure_message):
+def test_shorten_and_escape_failure_message():
     with open('./tests/windows.junit.xml') as f:
         failure_message = f.read()
 
@@ -56,32 +53,71 @@ def test_shorten_and_escape_failure_message(shorten_file_paths, escape_failure_m
     assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&amp;lt;anonymous&amp;gt;<br>(.../demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(.../jest-circus/build/utils.js:298:28)<br>at new Promise (&amp;lt;anonymous&amp;gt;)<br>at callAsyncCircusFn<br>(.../jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(.../jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(.../jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(.../jest-circus/build/run.js:126:9)<br>at run<br>(.../jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(.../build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(.../build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(.../jest-runner/build/runTest.js:367:16)<br>at runTest<br>(.../jest-runner/build/runTest.js:444:34)"""
 
 
-@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
-def test_escape_failure_message_happy_path(escape_failure_message):
+def test_escape_failure_message_happy_path():
     failure_message = "\"'<>&\r\n"
     res = escape_failure_message(failure_message)
     assert res == "&amp;quot;&amp;apos;&amp;lt;&amp;gt;&amp;<br>"
 
-@pytest.mark.parametrize("escape_failure_message", [escape_failure_message_pystring, escape_failure_message_rust_string])
-def test_escape_failure_message_slash_in_message(escape_failure_message):
+def test_escape_failure_message_slash_in_message():
     failure_message = "\\ \\n \n"
     res = escape_failure_message(failure_message)
     assert res == "\\ \\n <br>"
 
-@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
-def test_shorten_file_paths_short_path(shorten_file_paths):
+def test_shorten_file_paths_short_path():
     failure_message = "short/file/path.txt"
     res = shorten_file_paths(failure_message)
     assert res == failure_message
 
-@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
-def test_shorten_file_paths_long_path(shorten_file_paths):
+def test_shorten_file_paths_long_path():
     failure_message = "very/long/file/path/should/be/shortened.txt"
     res = shorten_file_paths(failure_message)
     assert res == ".../should/be/shortened.txt"
 
-@pytest.mark.parametrize("shorten_file_paths", [shorten_file_paths_pystring, shorten_file_paths_rust_string])
-def test_shorten_file_paths_long_path_leading_slash(shorten_file_paths):
+def test_shorten_file_paths_long_path_leading_slash():
     failure_message = "/very/long/file/path/should/be/shortened.txt"
     res = shorten_file_paths(failure_message)
     assert res == ".../should/be/shortened.txt"
+
+def test_build_message():
+    @dataclass
+    class Thing:
+        failed = 0
+        passed = 0
+        skipped = 0
+        failures = []
+
+    @dataclass
+    class Run:
+        name = ""
+        testsuite = ""
+        failure_message = ""
+        
+    run1 = Run()
+    run2 = Run()
+
+    run1.name = "hello"
+    run1.testsuite = "world"
+    run1.failure_message = "I failed"
+
+
+    run2.name = "hello"
+    run2.testsuite = "again"
+    run2.failure_message = None
+
+    payload = Thing()
+    payload.passed = 1
+    payload.failed = 2
+    payload.skipped = 3
+    payload.failures = [run1, run2]
+
+    res = build_message(payload)
+
+    assert res == """### :x: Failed Test Results: 
+Completed 6 tests with **`2 failed`**, 1 passed and 3 skipped.
+<details><summary>View the full list of failed tests</summary>
+
+| **Test Description** | **Failure message** |
+| :-- | :-- |
+| <pre>Testsuite:<br>hello<br><br>Test name:<br>world<br></pre> | <pre>I failed</pre> |
+| <pre>Testsuite:<br>hello<br><br>Test name:<br>again<br></pre> | <pre>No failure message available</pre> |"""
+

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -1,0 +1,55 @@
+from test_results_parser import escape_failure_message, shorten_file_paths
+
+
+def test_escape_failure_message():
+    with open('./tests/windows.junit.xml') as f:
+        failure_message = f.read()
+    res = escape_failure_message(failure_message)
+
+    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&lt;anonymous&gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&lt;anonymous&gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""
+
+
+
+def test_shorten_file_paths():
+    with open('./tests/windows.junit.xml') as f:
+        failure_message = f.read()
+
+    res = shorten_file_paths(failure_message)
+
+    assert res == """Error: expect(received).toBe(expected) // Object.is equality
+
+Expected: 4
+Received: 5
+at Object.&lt;anonymous&gt;
+(.../calculator.test.ts:5:26/calculator/demo)
+at Promise.then.completed
+(.../utils.js:298:28/build/jest-circus)
+at new Promise (&lt;anonymous&gt;)
+at callAsyncCircusFn
+(.../utils.js:231:10/build/jest-circus)
+at _callCircusTest
+(.../run.js:316:40/build/jest-circus)
+at processTicksAndRejections (node:internal/process/task_queues:95:5)
+at _runTest
+(.../run.js:252:3/build/jest-circus)
+at _runTestsForDescribeBlock
+(.../run.js:126:9/build/jest-circus)
+at run
+(.../run.js:71:3/build/jest-circus)
+at runAndTransformResultsToJestFormat
+(.../jestAdapterInit.js:122:21/legacy-code-todo-rewrite/build)
+at jestAdapter
+(.../jestAdapter.js:79:19/legacy-code-todo-rewrite/build)
+at runTestInternal
+(.../runTest.js:367:16/build/jest-runner)
+at runTest
+(.../runTest.js:444:34/build/jest-runner)"""
+
+def test_both():
+    with open('./tests/windows.junit.xml') as f:
+        failure_message = f.read()
+
+    partial_res = shorten_file_paths(failure_message)
+    res = escape_failure_message(failure_message)
+   
+    assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&lt;anonymous&gt;<br>(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)<br>at new Promise (&lt;anonymous&gt;)<br>at callAsyncCircusFn<br>(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)<br>at run<br>(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)<br>at runTest<br>(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)"""

--- a/tests/windows.junit.xml
+++ b/tests/windows.junit.xml
@@ -1,0 +1,28 @@
+Error: expect(received).toBe(expected) // Object.is equality
+
+Expected: 4
+Received: 5
+at Object.&lt;anonymous&gt;
+(/Users/user/dev/repo/demo/calculator/calculator.test.ts:5:26)
+at Promise.then.completed
+(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:298:28)
+at new Promise (&lt;anonymous&gt;)
+at callAsyncCircusFn
+(/Users/user/dev/repo/node_modules/jest-circus/build/utils.js:231:10)
+at _callCircusTest
+(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:316:40)
+at processTicksAndRejections (node:internal/process/task_queues:95:5)
+at _runTest
+(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:252:3)
+at _runTestsForDescribeBlock
+(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:126:9)
+at run
+(/Users/user/dev/repo/node_modules/jest-circus/build/run.js:71:3)
+at runAndTransformResultsToJestFormat
+(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+at jestAdapter
+(/Users/user/dev/repo/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+at runTestInternal
+(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:367:16)
+at runTest
+(/Users/user/dev/repo/node_modules/jest-runner/build/runTest.js:444:34)


### PR DESCRIPTION
This commit ports over two functions for manipulating failure messages:
- escape_failure_message:

  escapes a failure message to prepare it to be displayed in the comment so that the content of the failure message does not interfere with the formatting of the PR comment.

- shorten_file_paths:

  truncates the beginning of long file paths in the failure message in order to reduce the horizontal space a failure message takes up.