### PR TITLE
build: add alpine job to build musllinux wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,29 @@ jobs:
           name: wheels
           path: dist
 
+  alpine:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, x86, aarch64, armv7]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
   windows:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
The prebuilt manylinux wheels don't work on Alpine which is [breaking the CLI build](https://github.com/codecov/codecov-cli/actions/runs/8756179568/job/24032020853?pr=424#step:4:135)