### PR TITLE
Optimize Rust code and fix double-html-escaping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           . venv/bin/activate
           python -m pytest --cov-report=xml:coverage.xml --cov=. --junitxml=unit.junit.xml
-      
+
       - name: Upload results to codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
@@ -39,7 +39,6 @@ jobs:
           url: ${{ secrets.CODECOV_URL }}
           file: unit.junit.xml
           disable_search: true
-
 
       - name: Upload results to codecov
         if: ${{ !cancelled() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "4091e032efecb09d7b1f711f487b85ab925632a842627e3200fb088382cde32c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "either"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,15 +40,6 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -318,7 +303,6 @@ checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 name = "test_results_parser"
 version = "0.2.0"
 dependencies = [
- "itertools",
  "pyo3",
  "quick-xml",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,12 +63,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +319,6 @@ name = "test_results_parser"
 version = "0.2.0"
 dependencies = [
  "itertools",
- "lazy_static",
  "pyo3",
  "quick-xml",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "cfg-if"
@@ -31,102 +25,76 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "portable-atomic"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -135,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -145,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -155,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -167,12 +135,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -188,27 +157,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -218,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -229,36 +189,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -267,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -277,16 +231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -295,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "test_results_parser"
@@ -321,60 +269,3 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,48 +129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,21 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,12 +298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +326,6 @@ version = "0.2.0"
 dependencies = [
  "itertools",
  "lazy_static",
- "phf",
  "pyo3",
  "quick-xml",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 itertools = "0.12.1"
-lazy_static = "1.4.0"
 pyo3 = "0.20.1"
 quick-xml = "0.31.0"
 regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "test_results_parser"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.20.1"
+pyo3 = "0.22.2"
 quick-xml = "0.36.0"
 regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ name = "test_results_parser"
 crate-type = ["cdylib"]
 
 [dependencies]
-itertools = "0.12.1"
 pyo3 = "0.20.1"
 quick-xml = "0.31.0"
 regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 itertools = "0.12.1"
 lazy_static = "1.4.0"
-phf = { version = "0.11.2", features = ["macros"] }
 pyo3 = "0.20.1"
 quick-xml = "0.31.0"
 regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.20.1"
-quick-xml = "0.31.0"
+quick-xml = "0.36.0"
 regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -53,7 +53,7 @@ pub fn shorten_file_paths(failure_message: String) -> String {
     let mut resulting_string = failure_message.clone();
     for m in SHORTEN_PATH_PATTERN.find_iter(&failure_message) {
         let filepath = m.as_str();
-        let split_file_path: Vec<_> = filepath.split("/").collect();
+        let split_file_path: Vec<_> = filepath.split('/').collect();
 
         if split_file_path.len() > 3 {
             let mut slice = split_file_path.iter().rev().take(3).rev();
@@ -99,7 +99,7 @@ pub struct MessagePayload {
 }
 
 #[pyfunction]
-pub fn build_message<'py>(py: Python<'py>, payload: MessagePayload) -> PyResult<&'py PyString> {
+pub fn build_message(py: Python<'_>, payload: MessagePayload) -> PyResult<&PyString> {
     let mut message: Vec<String> = Vec::new();
     let header = s("### :x: Failed Test Results: ");
     message.push(header);
@@ -136,5 +136,5 @@ pub fn build_message<'py>(py: Python<'py>, payload: MessagePayload) -> PyResult<
         message.push(single_test_row);
     }
 
-    Ok(&PyString::new(py, &message.join("\n")))
+    Ok(PyString::new(py, &message.join("\n")))
 }

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use phf::phf_ordered_map;
 
 use pyo3::{prelude::*, types::PyString};
 
@@ -8,25 +7,22 @@ use regex::Regex;
 
 use crate::helpers::s;
 
-// Need to use an ordered map to make sure we replace '>' before
-// we replace '\n', so that we don't replace the '>' in '<br>'
-static REPLACEMENTS: phf::OrderedMap<&'static str, &'static str> = phf_ordered_map! {
-    "\"" => "&quot;",
-    "'" => "&apos;",
-    "<" => "&lt;",
-    ">" => "&gt;",
-    "&" => "&amp;",
-    "\r" =>  "",
-    "\n" =>  "<br>",
-};
-
 #[pyfunction]
-pub fn escape_failure_message(failure_message: String) -> String {
-    let mut escaped_failure_message = failure_message.clone();
-    for (from, to) in REPLACEMENTS.entries() {
-        escaped_failure_message = escaped_failure_message.replace(from, to);
+pub fn escape_failure_message(failure_message: &str) -> String {
+    let mut e = String::new();
+    for c in failure_message.chars() {
+        match c {
+            '\"' => e.push_str("&quot;"),
+            '\'' => e.push_str("&apos;"),
+            '<' => e.push_str("&lt;"),
+            '>' => e.push_str("&gt;"),
+            '&' => e.push_str("&amp;"),
+            '\r' => {}
+            '\n' => e.push_str("<br>"),
+            c => e.push(c),
+        }
     }
-    escaped_failure_message
+    e
 }
 
 /*
@@ -78,7 +74,7 @@ fn generate_failure_info(failure_message: &Option<String>) -> String {
         Some(x) => {
             let mut resulting_string = x.clone();
             resulting_string = shorten_file_paths(resulting_string);
-            resulting_string = escape_failure_message(resulting_string);
+            resulting_string = escape_failure_message(&resulting_string);
             resulting_string
         }
     }

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -1,8 +1,6 @@
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
 
 use pyo3::{prelude::*, types::PyString};
-
-use itertools::Itertools;
 use regex::Regex;
 
 use crate::helpers::s;
@@ -25,40 +23,43 @@ pub fn escape_failure_message(failure_message: &str) -> String {
     e
 }
 
-/*
-Examples of strings that match:
-
-/path/to/file.txt
-/path/to/file
-/path/to
-path/to:1:2
-/path/to/file.txt:1:2
-
-Examples of strings that don't match:
-
-path
-file.txt
-*/
-lazy_static! {
-    static ref SHORTEN_PATH_PATTERN: Regex =
-        Regex::new(r"(?:\/*[\w\-]+\/)+(?:[\w\.]+)(?::\d+:\d+)*").unwrap();
-}
-
 #[pyfunction]
-pub fn shorten_file_paths(failure_message: String) -> String {
-    let mut resulting_string = failure_message.clone();
-    for m in SHORTEN_PATH_PATTERN.find_iter(&failure_message) {
+pub fn shorten_file_paths(failure_message: &str) -> String {
+    static SHORTEN_PATH_PATTERN: OnceLock<Regex> = OnceLock::new();
+    /*
+    Examples of strings that match:
+
+    /path/to/file.txt
+    /path/to/file
+    /path/to
+    path/to:1:2
+    /path/to/file.txt:1:2
+
+    Examples of strings that don't match:
+
+    path
+    file.txt
+    */
+    let re = SHORTEN_PATH_PATTERN
+        .get_or_init(|| Regex::new(r"(?:\/*[\w\-]+\/)+(?:[\w\.]+)(?::\d+:\d+)*").unwrap());
+
+    let mut new = String::with_capacity(failure_message.len());
+    let mut last_match = 0;
+    for caps in re.captures_iter(failure_message) {
+        let m = caps.get(0).unwrap();
         let filepath = m.as_str();
-        let split_file_path: Vec<_> = filepath.split('/').collect();
 
-        if split_file_path.len() > 3 {
-            let mut slice = split_file_path.iter().rev().take(3).rev();
-
-            let s = format!("{}{}", ".../", slice.join("/"));
-            resulting_string = resulting_string.replace(filepath, &s);
+        if let Some((third_last_slash_idx, _)) = filepath.rmatch_indices('/').nth(3) {
+            new.push_str(".../");
+            new.push_str(&filepath[third_last_slash_idx..]);
+        } else {
+            new.push_str(&failure_message[last_match..m.end()]);
         }
+        last_match = m.end();
     }
-    resulting_string
+    new.push_str(&failure_message[last_match..]);
+
+    new
 }
 
 fn generate_test_description(testsuite: &String, name: &String) -> String {
@@ -71,12 +72,7 @@ fn generate_test_description(testsuite: &String, name: &String) -> String {
 fn generate_failure_info(failure_message: &Option<String>) -> String {
     match failure_message {
         None => s("No failure message available"),
-        Some(x) => {
-            let mut resulting_string = x.clone();
-            resulting_string = shorten_file_paths(resulting_string);
-            resulting_string = escape_failure_message(&resulting_string);
-            resulting_string
-        }
+        Some(x) => escape_failure_message(&shorten_file_paths(x)),
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,0 @@
-use pyo3::exceptions::PyException;
-
-pub fn s(string_slice: &str) -> String {
-    string_slice.to_string()
-}
-
-pyo3::create_exception!(mymodule, ParserError, PyException);

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -5,8 +5,8 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use std::collections::HashMap;
 
-use crate::helpers::ParserError;
 use crate::testrun::{Outcome, Testrun};
+use crate::ParserError;
 
 // from https://gist.github.com/scott-codecov/311c174ecc7de87f7d7c50371c6ef927#file-cobertura-rs-L18-L31
 fn attributes_map(attributes: Attributes) -> Result<HashMap<String, String>, pyo3::PyErr> {

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 use quick_xml::events::attributes::Attributes;
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::reader::Reader;
 use std::collections::HashMap;
 
@@ -9,9 +9,11 @@ use crate::testrun::{Outcome, Testrun};
 use crate::ParserError;
 
 // from https://gist.github.com/scott-codecov/311c174ecc7de87f7d7c50371c6ef927#file-cobertura-rs-L18-L31
-fn attributes_map(attributes: Attributes) -> Result<HashMap<String, String>, pyo3::PyErr> {
+fn attributes_map(attributes: Attributes) -> PyResult<HashMap<String, String>> {
     let mut attr_map = HashMap::new();
-    for attribute in attributes.flatten() {
+    for attribute in attributes {
+        let attribute = attribute
+            .map_err(|e| ParserError::new_err(format!("Error parsing attribute: {}", e)))?;
         let bytes = attribute.value.into_owned();
         let value = String::from_utf8(bytes)?;
         let key = String::from_utf8(attribute.key.into_inner().to_vec())?;
@@ -20,13 +22,24 @@ fn attributes_map(attributes: Attributes) -> Result<HashMap<String, String>, pyo
     Ok(attr_map)
 }
 
-fn populate(attr_hm: &HashMap<String, String>, testsuite: String) -> Result<Testrun, pyo3::PyErr> {
+fn get_attribute(e: &BytesStart, name: &str) -> PyResult<Option<String>> {
+    let attr = if let Some(message) = e
+        .try_get_attribute(name)
+        .map_err(|e| ParserError::new_err(format!("Error parsing attribute: {}", e)))?
+    {
+        Some(String::from_utf8(message.value.to_vec())?)
+    } else {
+        None
+    };
+    Ok(attr)
+}
+
+fn populate(attr_hm: &HashMap<String, String>, testsuite: String) -> PyResult<Testrun> {
     let name = format!(
-        "{}{}{}",
+        "{}\x1f{}",
         attr_hm
             .get("classname")
             .ok_or(ParserError::new_err("No classname found"))?,
-        '\x1f',
         attr_hm
             .get("name")
             .ok_or(ParserError::new_err("No name found"))?
@@ -35,7 +48,6 @@ fn populate(attr_hm: &HashMap<String, String>, testsuite: String) -> Result<Test
     let duration = attr_hm
         .get("time")
         .ok_or(ParserError::new_err("No duration found"))?
-        .to_string()
         .parse()?;
 
     Ok(Testrun {
@@ -48,20 +60,17 @@ fn populate(attr_hm: &HashMap<String, String>, testsuite: String) -> Result<Test
 }
 
 #[pyfunction]
-pub fn parse_junit_xml(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
-    let file_string = String::from_utf8_lossy(&file_bytes).into_owned();
-    let mut reader = Reader::from_str(file_string.as_str());
-    reader.trim_text(true);
+pub fn parse_junit_xml(file_bytes: &[u8]) -> PyResult<Vec<Testrun>> {
+    let mut reader = Reader::from_reader(file_bytes);
+    reader.config_mut().trim_text(true);
 
     let mut list_of_test_runs = Vec::new();
-
-    let mut buf = Vec::new();
-
     let mut saved_testrun: Option<Testrun> = None;
 
     let mut curr_testsuite = String::new();
     let mut in_failure: bool = false;
 
+    let mut buf = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
             Err(e) => {
@@ -76,38 +85,33 @@ pub fn parse_junit_xml(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
             }
             Ok(Event::Start(e)) => match e.name().as_ref() {
                 b"testcase" => {
-                    let attr_hm = attributes_map(e.attributes());
-                    saved_testrun = Some(populate(&attr_hm?, curr_testsuite.clone())?);
+                    let attr_hm = attributes_map(e.attributes())?;
+                    saved_testrun = Some(populate(&attr_hm, curr_testsuite.clone())?);
                 }
                 b"skipped" => {
-                    let mut testrun = saved_testrun
+                    let testrun = saved_testrun
+                        .as_mut()
                         .ok_or(ParserError::new_err("Error accessing saved testrun"))?;
                     testrun.outcome = Outcome::Skip;
-                    saved_testrun = Some(testrun);
                 }
                 b"error" => {
-                    let mut testrun = saved_testrun
+                    let testrun = saved_testrun
+                        .as_mut()
                         .ok_or(ParserError::new_err("Error accessing saved testrun"))?;
                     testrun.outcome = Outcome::Error;
-                    saved_testrun = Some(testrun);
                 }
                 b"failure" => {
-                    let mut testrun = saved_testrun
+                    let testrun = saved_testrun
+                        .as_mut()
                         .ok_or(ParserError::new_err("Error accessing saved testrun"))?;
                     testrun.outcome = Outcome::Failure;
-                    let attr_hm = attributes_map(e.attributes())?;
-                    let tentative_message = attr_hm.get("message").cloned();
-                    testrun.failure_message = tentative_message;
-                    saved_testrun = Some(testrun);
+
+                    testrun.failure_message = get_attribute(&e, "message")?;
                     in_failure = true;
                 }
                 b"testsuite" => {
-                    let attr_hm = attributes_map(e.attributes());
-
-                    curr_testsuite = attr_hm?
-                        .get("name")
-                        .ok_or(ParserError::new_err("Error getting name".to_string()))?
-                        .to_string();
+                    curr_testsuite = get_attribute(&e, "name")?
+                        .ok_or(ParserError::new_err("Error getting name".to_string()))?;
                 }
                 _ => {}
             },
@@ -124,13 +128,14 @@ pub fn parse_junit_xml(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
             },
             Ok(Event::Empty(e)) => {
                 if e.name().as_ref() == b"testcase" {
-                    let attr_hm = attributes_map(e.attributes());
-                    list_of_test_runs.push(populate(&attr_hm?, curr_testsuite.clone())?);
+                    let attr_hm = attributes_map(e.attributes())?;
+                    list_of_test_runs.push(populate(&attr_hm, curr_testsuite.clone())?);
                 }
             }
             Ok(Event::Text(x)) => {
                 if in_failure {
-                    let mut testrun = saved_testrun
+                    let testrun = saved_testrun
+                        .as_mut()
                         .ok_or(ParserError::new_err("Error accessing saved testrun"))?;
 
                     let mut xml_failure_message = x.into_owned();
@@ -139,8 +144,6 @@ pub fn parse_junit_xml(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
 
                     testrun.failure_message =
                         Some(String::from_utf8(xml_failure_message.as_ref().to_vec())?);
-
-                    saved_testrun = Some(testrun);
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pyo3::create_exception!(test_results_parser, ParserError, PyException);
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn test_results_parser(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("ParserError", _py.get_type::<ParserError>())?;
+fn test_results_parser(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add("ParserError", py.get_type_bound::<ParserError>())?;
     m.add_class::<testrun::Testrun>()?;
     m.add_class::<testrun::Outcome>()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
+use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
 mod failure_message;
-mod helpers;
 mod junit;
 mod pytest_reportlog;
 mod testrun;
 mod vitest_json;
 
+pyo3::create_exception!(test_results_parser, ParserError, PyException);
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn test_results_parser(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("ParserError", _py.get_type::<helpers::ParserError>())?;
+    m.add("ParserError", _py.get_type::<ParserError>())?;
     m.add_class::<testrun::Testrun>()?;
     m.add_class::<testrun::Outcome>()?;
 

--- a/src/pytest_reportlog.rs
+++ b/src/pytest_reportlog.rs
@@ -95,11 +95,7 @@ pub fn parse_pytest_reportlog(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
     let mut saved_failure_message: Option<String> = None;
     let mut saved_outcome: Option<Outcome> = None;
 
-    let mut lineno = 0;
-
-    let string_lines = file_string.lines();
-
-    for line in string_lines {
+    for (lineno, line) in file_string.lines().enumerate() {
         let val: PytestLine = serde_json::from_str(line)
             .map_err(|err| ParserError::new_err(format!("Error parsing json line  {}", err)))?;
 
@@ -178,7 +174,6 @@ pub fn parse_pytest_reportlog(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
                 _ => (),
             }
         }
-        lineno += 1;
     }
 
     Ok(testruns)

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -3,8 +3,6 @@ use std::fmt::Display;
 use pyo3::class::basic::CompareOp;
 use pyo3::{prelude::*, pyclass};
 
-use crate::helpers::s;
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[pyclass]
 pub enum Outcome {
@@ -17,9 +15,8 @@ pub enum Outcome {
 #[pymethods]
 impl Outcome {
     #[new]
-    fn new(value: String) -> Self {
-        let val = value.as_str();
-        match val {
+    fn new(value: &str) -> Self {
+        match value {
             "pass" => Outcome::Pass,
             "failure" => Outcome::Failure,
             "error" => Outcome::Error,
@@ -28,12 +25,12 @@ impl Outcome {
         }
     }
 
-    fn __str__(&self) -> String {
+    fn __str__(&self) -> &str {
         match &self {
-            Outcome::Pass => s("pass"),
-            Outcome::Failure => s("failure"),
-            Outcome::Error => s("error"),
-            Outcome::Skip => s("skip"),
+            Outcome::Pass => "pass",
+            Outcome::Failure => "failure",
+            Outcome::Error => "error",
+            Outcome::Skip => "skip",
         }
     }
 }
@@ -67,10 +64,10 @@ pub struct Testrun {
 impl Testrun {
     pub fn empty() -> Testrun {
         Testrun {
-            name: s(""),
+            name: "".into(),
             duration: 0.0,
             outcome: Outcome::Pass,
-            testsuite: s(""),
+            testsuite: "".into(),
             failure_message: None,
         }
     }

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -4,7 +4,7 @@ use pyo3::class::basic::CompareOp;
 use pyo3::{prelude::*, pyclass};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum Outcome {
     Pass,
     Error,
@@ -76,6 +76,7 @@ impl Testrun {
 #[pymethods]
 impl Testrun {
     #[new]
+    #[pyo3(signature = (name, duration, outcome, testsuite, failure_message=None))]
     fn new(
         name: String,
         duration: f64,

--- a/src/vitest_json.rs
+++ b/src/vitest_json.rs
@@ -2,8 +2,8 @@ use pyo3::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::ParserError;
 use crate::testrun::{Outcome, Testrun};
+use crate::ParserError;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct AssertionResult {
@@ -36,9 +36,8 @@ struct VitestReport {
 pub fn parse_vitest_json(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
     let file_string = String::from_utf8_lossy(&file_bytes).into_owned();
 
-    let val: VitestReport = serde_json::from_str(file_string.as_str()).map_err(|err| {
-        ParserError::new_err(format!("Error parsing vitest JSON: {}", err))
-    })?;
+    let val: VitestReport = serde_json::from_str(file_string.as_str())
+        .map_err(|err| ParserError::new_err(format!("Error parsing vitest JSON: {}", err)))?;
 
     let testruns: Result<Vec<Testrun>, _> = val
         .test_results

--- a/src/vitest_json.rs
+++ b/src/vitest_json.rs
@@ -37,7 +37,7 @@ pub fn parse_vitest_json(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
     let file_string = String::from_utf8_lossy(&file_bytes).into_owned();
 
     let val: VitestReport = serde_json::from_str(file_string.as_str()).map_err(|err| {
-        ParserError::new_err(format!("Error parsing vitest JSON: {}", err.to_string()))
+        ParserError::new_err(format!("Error parsing vitest JSON: {}", err))
     })?;
 
     let testruns: Result<Vec<Testrun>, _> = val
@@ -73,5 +73,5 @@ pub fn parse_vitest_json(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
         })
         .collect();
 
-    Ok(testruns?)
+    testruns
 }

--- a/src/vitest_json.rs
+++ b/src/vitest_json.rs
@@ -33,44 +33,35 @@ struct VitestReport {
 }
 
 #[pyfunction]
-pub fn parse_vitest_json(file_bytes: Vec<u8>) -> PyResult<Vec<Testrun>> {
-    let file_string = String::from_utf8_lossy(&file_bytes).into_owned();
-
-    let val: VitestReport = serde_json::from_str(file_string.as_str())
+pub fn parse_vitest_json(file_bytes: &[u8]) -> PyResult<Vec<Testrun>> {
+    let val: VitestReport = serde_json::from_slice(file_bytes)
         .map_err(|err| ParserError::new_err(format!("Error parsing vitest JSON: {}", err)))?;
 
-    let testruns: Result<Vec<Testrun>, _> = val
-        .test_results
+    val.test_results
         .into_iter()
         .flat_map(|result| {
-            result
-                .assertion_results
-                .into_iter()
-                .map(move |aresult| {
-                    Ok(Testrun {
-                        name: aresult.full_name,
-                        duration: aresult.duration_milliseconds as f64 / 1000.0,
-                        outcome: (match aresult.status.as_str() {
-                            "failed" => Outcome::Failure,
-                            "pending" => Outcome::Skip,
-                            "passed" => Outcome::Pass,
-                            x => {
-                                return Err(ParserError::new_err(format!(
-                                    "Error reading outcome. {} is an invalid value",
-                                    x
-                                )))
-                            }
-                        }),
-                        testsuite: result.name.clone(),
-                        failure_message: match aresult.failure_messages.len() {
-                            0 => None,
-                            _ => Some(aresult.failure_messages.join(" ")),
-                        },
-                    })
+            result.assertion_results.into_iter().map(move |aresult| {
+                Ok(Testrun {
+                    name: aresult.full_name,
+                    duration: aresult.duration_milliseconds as f64 / 1000.0,
+                    outcome: (match aresult.status.as_str() {
+                        "failed" => Outcome::Failure,
+                        "pending" => Outcome::Skip,
+                        "passed" => Outcome::Pass,
+                        x => {
+                            return Err(ParserError::new_err(format!(
+                                "Error reading outcome. {} is an invalid value",
+                                x
+                            )))
+                        }
+                    }),
+                    testsuite: result.name.clone(),
+                    failure_message: match aresult.failure_messages.len() {
+                        0 => None,
+                        _ => Some(aresult.failure_messages.join(" ")),
+                    },
                 })
-                .collect::<Vec<_>>()
+            })
         })
-        .collect();
-
-    testruns
+        .collect()
 }

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -49,14 +49,14 @@ def test_shorten_and_escape_failure_message():
 
     partial_res = shorten_file_paths(failure_message)
     res = escape_failure_message(partial_res)
-   
+
     assert res == """Error: expect(received).toBe(expected) // Object.is equality<br><br>Expected: 4<br>Received: 5<br>at Object.&amp;lt;anonymous&amp;gt;<br>(.../demo/calculator/calculator.test.ts:5:26)<br>at Promise.then.completed<br>(.../jest-circus/build/utils.js:298:28)<br>at new Promise (&amp;lt;anonymous&amp;gt;)<br>at callAsyncCircusFn<br>(.../jest-circus/build/utils.js:231:10)<br>at _callCircusTest<br>(.../jest-circus/build/run.js:316:40)<br>at processTicksAndRejections (node:internal/process/task_queues:95:5)<br>at _runTest<br>(.../jest-circus/build/run.js:252:3)<br>at _runTestsForDescribeBlock<br>(.../jest-circus/build/run.js:126:9)<br>at run<br>(.../jest-circus/build/run.js:71:3)<br>at runAndTransformResultsToJestFormat<br>(.../build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)<br>at jestAdapter<br>(.../build/legacy-code-todo-rewrite/jestAdapter.js:79:19)<br>at runTestInternal<br>(.../jest-runner/build/runTest.js:367:16)<br>at runTest<br>(.../jest-runner/build/runTest.js:444:34)"""
 
 
 def test_escape_failure_message_happy_path():
     failure_message = "\"'<>&\r\n"
     res = escape_failure_message(failure_message)
-    assert res == "&amp;quot;&amp;apos;&amp;lt;&amp;gt;&amp;<br>"
+    assert res == "&quot;&apos;&lt;&gt;&amp;<br>"
 
 def test_escape_failure_message_slash_in_message():
     failure_message = "\\ \\n \n"
@@ -91,17 +91,17 @@ def test_build_message():
         name = ""
         testsuite = ""
         failure_message = ""
-        
+
     run1 = Run()
     run2 = Run()
 
-    run1.name = "hello"
-    run1.testsuite = "world"
+    run1.testsuite = "hello"
+    run1.name = "world"
     run1.failure_message = "I failed"
 
 
-    run2.name = "hello"
-    run2.testsuite = "again"
+    run2.testsuite = "hello"
+    run2.name = "again"
     run2.failure_message = None
 
     payload = Thing()
@@ -112,7 +112,7 @@ def test_build_message():
 
     res = build_message(payload)
 
-    assert res == """### :x: Failed Test Results: 
+    assert res == """### :x: Failed Test Results:
 Completed 6 tests with **`2 failed`**, 1 passed and 3 skipped.
 <details><summary>View the full list of failed tests</summary>
 
@@ -120,4 +120,3 @@ Completed 6 tests with **`2 failed`**, 1 passed and 3 skipped.
 | :-- | :-- |
 | <pre>Testsuite:<br>hello<br><br>Test name:<br>world<br></pre> | <pre>I failed</pre> |
 | <pre>Testsuite:<br>hello<br><br>Test name:<br>again<br></pre> | <pre>No failure message available</pre> |"""
-


### PR DESCRIPTION
This PR is rewriting large parts of the Rust code with the following aim:

- Removing dependencies that are not strictly needed, and update all the other dependencies.
- Avoid tons of intermediate allocations of `String`s, `Vec`s and `HashMap`s.

Apart from that, it also naturally fixes a double-html-escaping bug, which would erronously escape `"` as `&amp;quot;`.

---

The PR can be reviewed one commit at a time, as this refactoring was done step by step. Except the last commit which fixed a bunch of test failures / regressions introduced earlier, so the commits are not quite as "self contained".