### PR TITLE
feat: handle not having a classname in the rel_attrs

### DIFF
--- a/src/junit.rs
+++ b/src/junit.rs
@@ -55,10 +55,7 @@ fn populate(
     testsuite: String,
     testsuite_time: Option<String>,
 ) -> PyResult<Testrun> {
-    let classname = match rel_attrs.classname {
-        None => "".to_string(),
-        Some(x) => x,
-    };
+    let classname = rel_attrs.classname.unwrap_or_default();
 
     let name = rel_attrs
         .name

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -55,9 +55,11 @@ fn populate(
     testsuite: String,
     testsuite_time: Option<String>,
 ) -> PyResult<Testrun> {
-    let classname = rel_attrs
-        .classname
-        .ok_or_else(|| ParserError::new_err("No classname found"))?;
+    let classname = match rel_attrs.classname {
+        None => "".to_string(),
+        Some(x) => x,
+    };
+
     let name = rel_attrs
         .name
         .ok_or_else(|| ParserError::new_err("No name found"))?;

--- a/tests/phpunit.junit.xml
+++ b/tests/phpunit.junit.xml
@@ -15,7 +15,7 @@
                 name="test2"
                 file="/file1.php"
                 line="2"
-                classname="class.className" assertions="1"
+                assertions="1"
                 time="0.1" />
         </testsuite>
     </testsuite>

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -218,7 +218,7 @@ tests/test_parsers.py:16: AssertionError""",
                         ),
                         Testrun(
                             "test2",
-                            "class.className",
+                            "",
                             0.1,
                             Outcome.Pass,
                             "Thing",


### PR DESCRIPTION
some JUnit XML files don't have a classname attribute on all the testcases so let's handle that by just setting the classname to an empty string if it's not found as an attribute