### PR TITLE
Add Rust linting to CI and pre-commit hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,19 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: clippy, rustfmt
+      - name: Lint
+        run: make lint
+        
   run_tests:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint
+        name: lint
+        description: "Lint and sort"
+        entry: make lint
+        pass_filenames: false
+        require_serial: true
+        language: system

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+lint:
+	cargo fmt --all --check
+	cargo clippy

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/src/failure_message.rs
+++ b/src/failure_message.rs
@@ -107,7 +107,8 @@ pub fn build_message(mut payload: MessagePayload) -> String {
         .take(3)
         .map(|failure| {
             let failure_message = failure
-                .failure_message.as_deref()
+                .failure_message
+                .as_deref()
                 .unwrap_or("No failure message available");
             let stack_trace: Vec<String> =
                 failure_message.split('\n').map(escape_message).collect();


### PR DESCRIPTION
This just ensures that we format and lint the code before pushing it up.