### PR TITLE
Bump to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "test_results_parser"
-version = "0.2.0"
+version = "0.5.0"
 dependencies = [
  "pyo3",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_results_parser"
-version = "0.2.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
We've created release tags for 0.4.0 and that was our last version. Although we have those tags, they don't look like they've actually been published. Creating a version beyond those just to start over.