### PR TITLE
Fix pipeline name matching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,10 +131,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@v4
-        with:
-          name: wheels
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          args: --non-interactive --skip-existing *


### PR DESCRIPTION
Sigh, another pipeline issue. Pipeline is failing on download name matching. This should download all the artifacts hopefully.