### PR TITLE
Add newline to parse Markdown properly

### DIFF
--- a/templates/test_results_message.md
+++ b/templates/test_results_message.md
@@ -20,4 +20,5 @@
 
 {% endfor %}
 </details>{% else %}:white_check_mark: All tests successful. No failed tests were found.{% endif %}
+
 :mega: Thoughts on this report? [Let Codecov know!](https://github.com/codecov/feedback/issues/304) | Powered by [Codecov](https://about.codecov.io/)

--- a/tests/test_failure_message.py
+++ b/tests/test_failure_message.py
@@ -72,6 +72,7 @@ def test_build_message_no_failures():
     res = build_message(payload)
 
     assert res == """:white_check_mark: All tests successful. No failed tests were found.
+
 :mega: Thoughts on this report? [Let Codecov know!](https://github.com/codecov/feedback/issues/304) | Powered by [Codecov](https://about.codecov.io/)"""
 
 
@@ -171,4 +172,5 @@ def test_build_message():
 
 
 </details>
+
 :mega: Thoughts on this report? [Let Codecov know!](https://github.com/codecov/feedback/issues/304) | Powered by [Codecov](https://about.codecov.io/)"""


### PR DESCRIPTION
The GitHub parser will not render markdown if it's too close to the HTML tags. Adding an extra newline will fix the issue with the Markdown links getting parsed properly. Otherwise, it's rendering the links as raw strings right now (not as links).