### PR TITLE
Support empty failure tags as used by ctest

### DIFF
--- a/tests/ctest.xml
+++ b/tests/ctest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Linux-c++"
+	tests="1"
+	failures="1"
+	disabled="0"
+	skipped="0"
+	hostname="Workstation"
+	time="33"
+	timestamp="2024-10-18T15:53:17"
+	>
+	<testcase name="a_unit_test" classname="a_unit_test" time="33.4734" status="fail">
+		<failure message="Failed"/>
+		<properties>
+			<property name="cmake_labels" value="unittest"/>
+		</properties>
+		<system-out>There's a lot of text here
+</system-out>
+	</testcase>
+</testsuite>

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -228,6 +228,23 @@ tests/test_parsers.py:16: AssertionError""",
                     ],
                 ),
             ),
+            (
+                "./tests/ctest.xml",
+                ParsingInfo(
+                    None,
+                    [
+                        Testrun(
+                            "a_unit_test",
+                            "a_unit_test",
+                            33.4734,
+                            Outcome.Failure,
+                            "Linux-c++",
+                            "Failed",
+                            None,
+                        )
+                    ],
+                ),
+            ),
         ],
     )
     def test_junit(self, filename, expected):


### PR DESCRIPTION
This change makes it so empty 'failure' tags are cause for the testcase to register as failed.

This is what the junit xml files can look like when produced by CTest.

For reference:
https://github.com/Kitware/CMake/blob/master/Source/CTest/cmCTestTestHandler.cxx#L2623