### PR TITLE
feat: always set computed name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "test_results_parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0.94"
 base16ct = { version = "0.2.0", features = ["std"] }
 indexmap = "2.6.0"
-pyo3 = { version = "0.23.3", features = ["abi3-py310", "anyhow"] }
+pyo3 = { version = "0.24.1", features = ["abi3-py310", "anyhow"] }
 quick-xml = "0.37.1"
 regex = "1.11.1"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/benches/binary.rs
+++ b/benches/binary.rs
@@ -183,7 +183,7 @@ fn create_random_testcases(
                         failure_message: None,
                         filename: None,
                         build_url: None,
-                        computed_name: None,
+                        computed_name: "".into(),
                     }
                 })
                 .collect();

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -32,7 +32,7 @@ mod tests {
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         }
     }
 

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -73,14 +73,18 @@ fn populate(
         failure_message: None,
         filename: rel_attrs.file,
         build_url: None,
-        computed_name: None,
+        computed_name: "".to_string(),
     };
 
     let framework = framework.or_else(|| t.framework());
-    if let Some(f) = framework {
-        let computed_name = compute_name(&t.classname, &t.name, f, t.filename.as_deref(), network);
-        t.computed_name = Some(computed_name);
-    };
+    let computed_name = compute_name(
+        &t.classname,
+        &t.name,
+        framework,
+        t.filename.as_deref(),
+        network,
+    );
+    t.computed_name = computed_name;
 
     Ok((t, framework))
 }

--- a/src/raw_upload.rs
+++ b/src/raw_upload.rs
@@ -113,7 +113,7 @@ mod tests {
         let base64_data = BASE64_STANDARD.encode(compressed);
         let upload_json = format!(
             r#"{{"network": [], "test_results_files": [{{"filename": "{}", "format": "base64+compressed", "data": "{}"}}]}}"#,
-            filename.split('/').last().unwrap(),
+            filename.split('/').next_back().unwrap(),
             base64_data,
         );
         upload_json.into()

--- a/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@ctest.xml.snap
+++ b/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@ctest.xml.snap
@@ -13,4 +13,4 @@ input_file: tests/ctest.xml
       failure_message: Failed
       filename: ~
       build_url: ~
-      computed_name: ~
+      computed_name: "a_unit_test::a_unit_test"

--- a/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@empty_failure.junit.xml.snap
+++ b/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@empty_failure.junit.xml.snap
@@ -13,7 +13,7 @@ input_file: tests/empty_failure.junit.xml
       failure_message: ~
       filename: "./test.rb"
       build_url: ~
-      computed_name: ~
+      computed_name: "test.test::test.test works"
     - name: test.test fails
       classname: test.test
       duration: 1
@@ -22,4 +22,4 @@ input_file: tests/empty_failure.junit.xml
       failure_message: TestError
       filename: "./test.rb"
       build_url: ~
-      computed_name: ~
+      computed_name: "test.test::test.test fails"

--- a/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@junit-nested-testsuite.xml.snap
+++ b/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@junit-nested-testsuite.xml.snap
@@ -13,7 +13,7 @@ input_file: tests/junit-nested-testsuite.xml
       failure_message: aaaaaaa
       filename: ~
       build_url: ~
-      computed_name: ~
+      computed_name: "tests.test_parsers.TestParsers::test_junit[junit.xml--True]"
     - name: "test_junit[jest-junit.xml--False]"
       classname: tests.test_parsers.TestParsers
       duration: 0.186

--- a/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@no-testsuite-name.xml.snap
+++ b/src/snapshots/test_results_parser__raw_upload__tests__parse_raw_upload_success@no-testsuite-name.xml.snap
@@ -13,4 +13,4 @@ input_file: tests/no-testsuite-name.xml
       failure_message: Failed
       filename: ~
       build_url: ~
-      computed_name: ~
+      computed_name: "a_unit_test::a_unit_test"

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -130,7 +130,7 @@ pub struct Testrun {
     #[pyo3(item)]
     pub build_url: Option<String>,
     #[pyo3(item)]
-    pub computed_name: Option<String>,
+    pub computed_name: String,
 }
 
 impl Testrun {
@@ -197,7 +197,7 @@ mod tests {
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -213,7 +213,7 @@ mod tests {
             failure_message: None,
             filename: Some(".py".to_string()),
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -229,7 +229,7 @@ mod tests {
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -245,7 +245,7 @@ mod tests {
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -261,7 +261,7 @@ mod tests {
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: None,
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -277,7 +277,7 @@ mod tests {
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: Some("https://example.com/build_url".to_string()),
-            computed_name: None,
+            computed_name: "".to_string(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }

--- a/test_results_parser.pyi
+++ b/test_results_parser.pyi
@@ -9,12 +9,10 @@ class Testrun(TypedDict):
     failure_message: str | None
     filename: str | None
     build_url: str | None
-    computed_name: str | None
-
+    computed_name: str
 
 class ParsingInfo(TypedDict):
-    framework: Literal["Pytest", "Jest", "Vitest", "PHPUnit"]
+    framework: Literal["Pytest", "Jest", "Vitest", "PHPUnit"] | None
     testruns: list[Testrun]
-
 
 def parse_raw_upload(raw_upload_bytes: bytes) -> tuple[list[ParsingInfo], bytes]: ...

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -190,7 +191,6 @@ wheels = [
 
 [[package]]
 name = "test-results-parser"
-version = "0.5.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
depends on #76 

i noticed that users were still seeing unescaped XML in their test
names in the UI and then realized its because we only unescape the
names in the compute_name function

the goal is to have the raw name and classname be used to identify
tests across runs but show the user something nice in the UI and this
achieves commit achieves that

also fixed another unrelated inaccuracy in the pyi