### PR TITLE
fix: enforce name length limit

### DIFF
--- a/benches/binary.rs
+++ b/benches/binary.rs
@@ -6,7 +6,7 @@ use rand::rngs::SmallRng;
 use rand::seq::SliceRandom as _;
 use rand::{Rng, SeedableRng};
 use test_results_parser::binary::*;
-use test_results_parser::{Outcome, Testrun};
+use test_results_parser::{Outcome, Testrun, ValidatedString};
 
 criterion_group!(benches, binary);
 criterion_main!(benches);
@@ -176,14 +176,14 @@ fn create_random_testcases(
 
                     Testrun {
                         name: name.try_into().unwrap(),
-                        classname: "".try_into().unwrap(),
+                        classname: ValidatedString::default(),
                         duration: Some(1.0),
                         outcome: Outcome::Pass,
-                        testsuite: "".try_into().unwrap(),
+                        testsuite: ValidatedString::default(),
                         failure_message: None,
                         filename: None,
                         build_url: None,
-                        computed_name: "".try_into().unwrap(),
+                        computed_name: ValidatedString::default(),
                     }
                 })
                 .collect();

--- a/benches/binary.rs
+++ b/benches/binary.rs
@@ -175,7 +175,7 @@ fn create_random_testcases(
                     let name = Alphanumeric.sample_string(rng, name_len);
 
                     Testrun {
-                        name,
+                        name: name.into(),
                         classname: "".into(),
                         duration: Some(1.0),
                         outcome: Outcome::Pass,

--- a/benches/binary.rs
+++ b/benches/binary.rs
@@ -175,15 +175,15 @@ fn create_random_testcases(
                     let name = Alphanumeric.sample_string(rng, name_len);
 
                     Testrun {
-                        name: name.into(),
-                        classname: "".into(),
+                        name: name.try_into().unwrap(),
+                        classname: "".try_into().unwrap(),
                         duration: Some(1.0),
                         outcome: Outcome::Pass,
-                        testsuite: "".into(),
+                        testsuite: "".try_into().unwrap(),
                         failure_message: None,
                         filename: None,
                         build_url: None,
-                        computed_name: "".into(),
+                        computed_name: "".try_into().unwrap(),
                     }
                 })
                 .collect();

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -18,21 +18,24 @@ mod tests {
     use raw::CommitHash;
     use timestamps::DAY;
 
-    use crate::testrun::{Outcome, Testrun};
+    use crate::{
+        testrun::{Outcome, Testrun},
+        validated_string::ValidatedString,
+    };
 
     use super::*;
 
     fn test() -> Testrun {
         Testrun {
             name: "abc".try_into().unwrap(),
-            classname: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
             duration: Some(1.0),
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         }
     }
 

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -18,27 +18,20 @@ mod tests {
     use raw::CommitHash;
     use timestamps::DAY;
 
-    use crate::{
-        testrun::{Outcome, Testrun},
-        validated_string::ValidatedString,
-    };
+    use crate::testrun::{Outcome, Testrun};
 
     use super::*;
 
     fn test() -> Testrun {
         Testrun {
-            name: "abc".into(),
-            classname: "".into(),
             name: "abc".try_into().unwrap(),
             classname: "".try_into().unwrap(),
             duration: Some(1.0),
             outcome: Outcome::Pass,
-            testsuite: "".into(),
             testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         }
     }
@@ -67,7 +60,6 @@ mod tests {
         test.duration = Some(2.0);
         session.insert(&test);
 
-        test.name = "def".into();
         test.name = "def".try_into().unwrap();
         test.outcome = Outcome::Skip;
         test.duration = Some(0.0);
@@ -102,7 +94,6 @@ mod tests {
         let mut session = writer.start_session(0, CommitHash::default(), &[]);
 
         session.insert(&test);
-        test.testsuite = "some testsuite".into();
         test.testsuite = "some testsuite".try_into().unwrap();
         session.insert(&test);
 

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -18,21 +18,24 @@ mod tests {
     use raw::CommitHash;
     use timestamps::DAY;
 
-    use crate::testrun::{Outcome, Testrun};
+    use crate::{
+        testrun::{Outcome, Testrun},
+        validated_string::ValidatedString,
+    };
 
     use super::*;
 
     fn test() -> Testrun {
         Testrun {
-            name: "abc".into(),
-            classname: "".into(),
+            name: ValidatedString::from_str("abc").unwrap(),
+            classname: ValidatedString::from_str("").unwrap(),
             duration: Some(1.0),
             outcome: Outcome::Pass,
-            testsuite: "".into(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         }
     }
 
@@ -60,7 +63,7 @@ mod tests {
         test.duration = Some(2.0);
         session.insert(&test);
 
-        test.name = "def".into();
+        test.name = ValidatedString::from_str("def").unwrap();
         test.outcome = Outcome::Skip;
         test.duration = Some(0.0);
         session.insert(&test);
@@ -94,7 +97,7 @@ mod tests {
         let mut session = writer.start_session(0, CommitHash::default(), &[]);
 
         session.insert(&test);
-        test.testsuite = "some testsuite".into();
+        test.testsuite = ValidatedString::from_str("some testsuite").unwrap();
         session.insert(&test);
 
         let mut buf = vec![];

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -27,15 +27,19 @@ mod tests {
 
     fn test() -> Testrun {
         Testrun {
-            name: ValidatedString::from_str("abc").unwrap(),
-            classname: ValidatedString::from_str("").unwrap(),
+            name: "abc".into(),
+            classname: "".into(),
+            name: "abc".try_into().unwrap(),
+            classname: "".try_into().unwrap(),
             duration: Some(1.0),
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".into(),
+            testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         }
     }
 
@@ -63,7 +67,8 @@ mod tests {
         test.duration = Some(2.0);
         session.insert(&test);
 
-        test.name = ValidatedString::from_str("def").unwrap();
+        test.name = "def".into();
+        test.name = "def".try_into().unwrap();
         test.outcome = Outcome::Skip;
         test.duration = Some(0.0);
         session.insert(&test);
@@ -97,7 +102,8 @@ mod tests {
         let mut session = writer.start_session(0, CommitHash::default(), &[]);
 
         session.insert(&test);
-        test.testsuite = ValidatedString::from_str("some testsuite").unwrap();
+        test.testsuite = "some testsuite".into();
+        test.testsuite = "some testsuite".try_into().unwrap();
         session.insert(&test);
 
         let mut buf = vec![];

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -83,9 +83,7 @@ fn populate(
         failure_message: None,
         filename: rel_attrs.file,
         build_url: None,
-        computed_name: ""
-            .try_into()
-            .context("Error converting computed name to ValidatedString")?,
+        computed_name: ValidatedString::default(),
     };
 
     let framework = framework.or_else(|| t.framework());

--- a/src/junit.rs
+++ b/src/junit.rs
@@ -15,13 +15,6 @@ struct RelevantAttrs {
     classname: Option<ValidatedString>,
     name: Option<ValidatedString>,
     time: Option<String>,
-    file: Option<String>,
-}
-
-fn convert_attribute(attribute: Attribute) -> Option<String> {
-    let bytes = attribute.value.into_owned();
-    let value = String::from_utf8(bytes).ok()?;
-    Some(value)
     file: Option<ValidatedString>,
 }
 
@@ -70,12 +63,8 @@ fn populate(
     testsuite_time: Option<&str>,
     framework: Option<Framework>,
     network: Option<&HashSet<String>>,
-) -> PyResult<(Testrun, Option<Framework>)> {
-    let classname = rel_attrs.classname.unwrap_or_default();
 ) -> Result<(Testrun, Option<Framework>)> {
-    let classname = rel_attrs
-        .classname
-        .unwrap_or_else(|| ValidatedString::default());
+    let classname = rel_attrs.classname.unwrap_or_default();
 
     let name = rel_attrs.name.context("No name found")?;
 
@@ -94,7 +83,6 @@ fn populate(
         failure_message: None,
         filename: rel_attrs.file,
         build_url: None,
-        computed_name: "".to_string(),
         computed_name: ""
             .try_into()
             .context("Error converting computed name to ValidatedString")?,
@@ -108,7 +96,6 @@ fn populate(
         t.filename.as_deref(),
         network,
     );
-    t.computed_name = computed_name;
     t.computed_name = ValidatedString::from_string(computed_name)
         .context("Error converting computed name to ValidatedString")?;
 
@@ -204,7 +191,6 @@ pub fn use_reader(
                     in_failure = true;
                 }
                 b"testsuite" => {
-                    testsuite_names.push(get_attribute(&e, "name")?);
                     testsuite_names.push(
                         get_attribute(&e, "name")?
                             .map(|s| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod failure_message;
 mod junit;
 mod raw_upload;
 mod testrun;
+mod validated_string;
 
 pub use testrun::{Outcome, Testrun};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod testrun;
 mod validated_string;
 
 pub use testrun::{Outcome, Testrun};
-
+pub use validated_string::ValidatedString;
 pyo3::create_exception!(test_results_parser, ComputeNameError, PyException);
 
 /// A Python module implemented in Rust.

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -191,15 +191,15 @@ mod tests {
     #[test]
     fn test_detect_framework_testsuite_name() {
         let t = Testrun {
-            classname: "".try_into().unwrap(),
-            name: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
+            name: ValidatedString::default(),
             duration: None,
             outcome: Outcome::Pass,
             testsuite: "pytest".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -207,15 +207,15 @@ mod tests {
     #[test]
     fn test_detect_framework_filenames() {
         let t = Testrun {
-            classname: "".try_into().unwrap(),
-            name: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
+            name: ValidatedString::default(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: None,
             filename: Some(".py".try_into().unwrap()),
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -224,14 +224,14 @@ mod tests {
     fn test_detect_framework_example_classname() {
         let t = Testrun {
             classname: ".py".try_into().unwrap(),
-            name: "".try_into().unwrap(),
+            name: ValidatedString::default(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -239,15 +239,15 @@ mod tests {
     #[test]
     fn test_detect_framework_example_name() {
         let t = Testrun {
-            classname: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
             name: ".py".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -255,15 +255,15 @@ mod tests {
     #[test]
     fn test_detect_framework_failure_messages() {
         let t = Testrun {
-            classname: "".try_into().unwrap(),
-            name: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
+            name: ValidatedString::default(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: None,
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -271,15 +271,15 @@ mod tests {
     #[test]
     fn test_detect_build_url() {
         let t = Testrun {
-            classname: "".try_into().unwrap(),
-            name: "".try_into().unwrap(),
+            classname: ValidatedString::default(),
+            name: ValidatedString::default(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".try_into().unwrap(),
+            testsuite: ValidatedString::default(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: Some("https://example.com/build_url".to_string()),
-            computed_name: "".try_into().unwrap(),
+            computed_name: ValidatedString::default(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -191,18 +191,14 @@ mod tests {
     #[test]
     fn test_detect_framework_testsuite_name() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
             classname: "".try_into().unwrap(),
             name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "pytest".to_string(),
             testsuite: "pytest".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
@@ -211,19 +207,14 @@ mod tests {
     #[test]
     fn test_detect_framework_filenames() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
             classname: "".try_into().unwrap(),
             name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
             testsuite: "".try_into().unwrap(),
             failure_message: None,
-            filename: Some(".py".to_string()),
             filename: Some(".py".try_into().unwrap()),
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
@@ -232,18 +223,14 @@ mod tests {
     #[test]
     fn test_detect_framework_example_classname() {
         let t = Testrun {
-            classname: ".py".to_string(),
-            name: "".to_string(),
             classname: ".py".try_into().unwrap(),
             name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
             testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
@@ -252,18 +239,14 @@ mod tests {
     #[test]
     fn test_detect_framework_example_name() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: ".py".to_string(),
             classname: "".try_into().unwrap(),
             name: ".py".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
             testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
@@ -272,18 +255,14 @@ mod tests {
     #[test]
     fn test_detect_framework_failure_messages() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
             classname: "".try_into().unwrap(),
             name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
             testsuite: "".try_into().unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
@@ -292,18 +271,14 @@ mod tests {
     #[test]
     fn test_detect_build_url() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
             classname: "".try_into().unwrap(),
             name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
             testsuite: "".try_into().unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: Some("https://example.com/build_url".to_string()),
-            computed_name: "".to_string(),
             computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -191,15 +191,19 @@ mod tests {
     #[test]
     fn test_detect_framework_testsuite_name() {
         let t = Testrun {
-            classname: ValidatedString::from_str("").unwrap(),
-            name: ValidatedString::from_str("").unwrap(),
+            classname: "".to_string(),
+            name: "".to_string(),
+            classname: "".try_into().unwrap(),
+            name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("pytest").unwrap(),
+            testsuite: "pytest".to_string(),
+            testsuite: "pytest".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -207,15 +211,20 @@ mod tests {
     #[test]
     fn test_detect_framework_filenames() {
         let t = Testrun {
-            classname: ValidatedString::from_str("").unwrap(),
-            name: ValidatedString::from_str("").unwrap(),
+            classname: "".to_string(),
+            name: "".to_string(),
+            classname: "".try_into().unwrap(),
+            name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".to_string(),
+            testsuite: "".try_into().unwrap(),
             failure_message: None,
-            filename: Some(ValidatedString::from_str(".py").unwrap()),
+            filename: Some(".py".to_string()),
+            filename: Some(".py".try_into().unwrap()),
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -223,15 +232,19 @@ mod tests {
     #[test]
     fn test_detect_framework_example_classname() {
         let t = Testrun {
-            classname: ValidatedString::from_str(".py").unwrap(),
-            name: ValidatedString::from_str("").unwrap(),
+            classname: ".py".to_string(),
+            name: "".to_string(),
+            classname: ".py".try_into().unwrap(),
+            name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".to_string(),
+            testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -239,15 +252,19 @@ mod tests {
     #[test]
     fn test_detect_framework_example_name() {
         let t = Testrun {
-            classname: ValidatedString::from_str("").unwrap(),
-            name: ValidatedString::from_str(".py").unwrap(),
+            classname: "".to_string(),
+            name: ".py".to_string(),
+            classname: "".try_into().unwrap(),
+            name: ".py".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".to_string(),
+            testsuite: "".try_into().unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -255,15 +272,19 @@ mod tests {
     #[test]
     fn test_detect_framework_failure_messages() {
         let t = Testrun {
-            classname: ValidatedString::from_str("").unwrap(),
-            name: ValidatedString::from_str("").unwrap(),
+            classname: "".to_string(),
+            name: "".to_string(),
+            classname: "".try_into().unwrap(),
+            name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".to_string(),
+            testsuite: "".try_into().unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: None,
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -271,15 +292,19 @@ mod tests {
     #[test]
     fn test_detect_build_url() {
         let t = Testrun {
-            classname: ValidatedString::from_str("").unwrap(),
-            name: ValidatedString::from_str("").unwrap(),
+            classname: "".to_string(),
+            name: "".to_string(),
+            classname: "".try_into().unwrap(),
+            name: "".try_into().unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: ValidatedString::from_str("").unwrap(),
+            testsuite: "".to_string(),
+            testsuite: "".try_into().unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: Some("https://example.com/build_url".to_string()),
-            computed_name: ValidatedString::from_str("").unwrap(),
+            computed_name: "".to_string(),
+            computed_name: "".try_into().unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -3,6 +3,8 @@ use pyo3::types::PyString;
 use pyo3::{PyAny, PyResult};
 use serde::Serialize;
 
+use crate::validated_string::ValidatedString;
+
 static FRAMEWORKS: [(&str, Framework); 4] = [
     ("pytest", Framework::Pytest),
     ("vitest", Framework::Vitest),
@@ -114,23 +116,23 @@ impl<'py> FromPyObject<'py> for Framework {
 #[derive(IntoPyObject, FromPyObject, Clone, Debug, Serialize, PartialEq)]
 pub struct Testrun {
     #[pyo3(item)]
-    pub name: String,
+    pub name: ValidatedString,
     #[pyo3(item)]
-    pub classname: String,
+    pub classname: ValidatedString,
     #[pyo3(item)]
     pub duration: Option<f64>,
     #[pyo3(item)]
     pub outcome: Outcome,
     #[pyo3(item)]
-    pub testsuite: String,
+    pub testsuite: ValidatedString,
     #[pyo3(item)]
     pub failure_message: Option<String>,
     #[pyo3(item)]
-    pub filename: Option<String>,
+    pub filename: Option<ValidatedString>,
     #[pyo3(item)]
     pub build_url: Option<String>,
     #[pyo3(item)]
-    pub computed_name: String,
+    pub computed_name: ValidatedString,
 }
 
 impl Testrun {
@@ -189,15 +191,15 @@ mod tests {
     #[test]
     fn test_detect_framework_testsuite_name() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
+            classname: ValidatedString::from_str("").unwrap(),
+            name: ValidatedString::from_str("").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "pytest".to_string(),
+            testsuite: ValidatedString::from_str("pytest").unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -205,15 +207,15 @@ mod tests {
     #[test]
     fn test_detect_framework_filenames() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
+            classname: ValidatedString::from_str("").unwrap(),
+            name: ValidatedString::from_str("").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: None,
-            filename: Some(".py".to_string()),
+            filename: Some(ValidatedString::from_str(".py").unwrap()),
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -221,15 +223,15 @@ mod tests {
     #[test]
     fn test_detect_framework_example_classname() {
         let t = Testrun {
-            classname: ".py".to_string(),
-            name: "".to_string(),
+            classname: ValidatedString::from_str(".py").unwrap(),
+            name: ValidatedString::from_str("").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -237,15 +239,15 @@ mod tests {
     #[test]
     fn test_detect_framework_example_name() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: ".py".to_string(),
+            classname: ValidatedString::from_str("").unwrap(),
+            name: ValidatedString::from_str(".py").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: None,
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -253,15 +255,15 @@ mod tests {
     #[test]
     fn test_detect_framework_failure_messages() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
+            classname: ValidatedString::from_str("").unwrap(),
+            name: ValidatedString::from_str("").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: None,
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }
@@ -269,15 +271,15 @@ mod tests {
     #[test]
     fn test_detect_build_url() {
         let t = Testrun {
-            classname: "".to_string(),
-            name: "".to_string(),
+            classname: ValidatedString::from_str("").unwrap(),
+            name: ValidatedString::from_str("").unwrap(),
             duration: None,
             outcome: Outcome::Pass,
-            testsuite: "".to_string(),
+            testsuite: ValidatedString::from_str("").unwrap(),
             failure_message: Some(".py".to_string()),
             filename: None,
             build_url: Some("https://example.com/build_url".to_string()),
-            computed_name: "".to_string(),
+            computed_name: ValidatedString::from_str("").unwrap(),
         };
         assert_eq!(t.framework(), Some(Framework::Pytest))
     }

--- a/src/validated_string.rs
+++ b/src/validated_string.rs
@@ -1,0 +1,66 @@
+use std::{convert::Infallible, ops::Deref};
+
+use anyhow::{Context, Result};
+use pyo3::{
+    types::{PyAnyMethods, PyString},
+    Bound, FromPyObject, IntoPyObject, PyAny, PyResult, Python,
+};
+use serde::{Deserialize, Serialize};
+
+// String that is validated to be less than 1000 characters
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ValidatedString {
+    value: String,
+}
+
+impl ValidatedString {
+    pub fn from_string(value: String) -> Result<Self> {
+        if value.len() > 1000 {
+            anyhow::bail!("string is too long");
+        }
+        Ok(Self { value })
+    }
+
+    pub fn from_str(value: &str) -> Result<Self> {
+        Self::from_string(value.to_string())
+    }
+}
+
+impl Deref for ValidatedString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<String> for ValidatedString {
+    fn from(value: String) -> Self {
+        Self::from_string(value).unwrap()
+    }
+}
+
+impl From<&str> for ValidatedString {
+    fn from(value: &str) -> Self {
+        Self::from_str(value).unwrap()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for ValidatedString {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, &self.value))
+    }
+}
+
+impl FromPyObject<'_> for ValidatedString {
+    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let s = obj.extract::<String>()?;
+        Ok(Self::from_string(s).context("Error converting PyString to ValidatedString")?)
+    }
+}


### PR DESCRIPTION
we want to limit the length of individual testrun fields (except for
failure messages). This is done for DB index limit reasons, but also
because if the testrun fields exceed this length, something is
probably wrong with the user's setup.