### PR TITLE
feat: Build python 3.9 wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13'
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -53,7 +53,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13'
           sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -77,7 +77,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -99,7 +99,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0.94"
 base16ct = { version = "0.2.0", features = ["std"] }
 indexmap = "2.6.0"
-pyo3 = { version = "0.24.1", features = ["abi3-py310", "anyhow"] }
+pyo3 = { version = "0.24.1", features = ["abi3-py39", "anyhow"] }
 quick-xml = "0.37.1"
 regex = "1.11.1"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "test_results_parser"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/src/testrun.rs
+++ b/src/testrun.rs
@@ -59,8 +59,8 @@ impl<'py> IntoPyObject<'py> for Outcome {
 
 impl<'py> FromPyObject<'py> for Outcome {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let s = ob.extract::<&str>()?;
-        match s {
+        let s = ob.extract::<String>()?;
+        match s.as_str() {
             "pass" => Ok(Outcome::Pass),
             "failure" => Ok(Outcome::Failure),
             "skip" => Ok(Outcome::Skip),
@@ -98,8 +98,8 @@ impl<'py> IntoPyObject<'py> for Framework {
 
 impl<'py> FromPyObject<'py> for Framework {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let s = ob.extract::<&str>()?;
-        match s {
+        let s = ob.extract::<String>()?;
+        match s.as_str() {
             "Pytest" => Ok(Framework::Pytest),
             "Vitest" => Ok(Framework::Vitest),
             "Jest" => Ok(Framework::Jest),


### PR DESCRIPTION
Updates the publish workflow to build a wheel for python 3.9. This should solve the issue I'm encountering where the CLI must build test-results-parser from source when on python 3.9, requiring build deps to be installed.

We will need to cut a new release after this in order to get the new wheel in pypi.