### PR TITLE
fix: remove python 3.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@
 #
 # It is tweaked by hand to use PyPI Trusted Publishers:
 # https://www.maturin.rs/distribution#using-pypis-trusted-publishing
-name: CI
+name: Publish
 
 on:
   release:
@@ -30,7 +30,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -53,7 +53,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
           sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -77,7 +77,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -99,7 +99,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           url: ${{ secrets.CODECOV_URL }}
           files: unit.junit.xml
           disable_search: true
-          report_type: test-results
+          report_type: test_results
 
       - name: Upload results to codecov (Staging)
         if: ${{ !cancelled() }}
@@ -64,4 +64,4 @@ jobs:
           url: ${{ secrets.CODECOV_STAGING_API_URL }}
           files: unit.junit.xml
           disable_search: true
-          report_type: test-results
+          report_type: test_results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - release
   pull_request:
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
           components: clippy, rustfmt
       - name: Lint
         run: make lint
-        
+
   run_tests:
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -371,7 +371,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "test_results_parser"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "pyo3",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_results_parser"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Remove support for python 3.8 as it has been end-of-lifed last year. This is preventing us from being able to release new versions of this package