### PR TITLE
chore(release): add py3.13 and py3.14 deliverables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14'
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -53,7 +53,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14'
           sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -77,7 +77,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -99,7 +99,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "heck"
@@ -403,7 +403,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "test_results_parser"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "pyo3",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_results_parser"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
fixes https://github.com/codecov/test-results-parser/issues/86

Adds py3.13 and py3.14 wheels for distribution