### PR TITLE
Rebrand ownership references from Functional Software/Sentry to Harness

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ FSL-1.1-Apache-2.0
 
 ## Notice
 
-Copyright 2008-2024 Functional Software, Inc. dba Sentry
+Copyright 2008-2026 Harness, Inc.
 
 ## Terms and Conditions
 


### PR DESCRIPTION
## Summary
Codecov is now owned by **Harness, Inc.** following the 2026 acquisition. This updates user-facing ownership/branding references that previously named Sentry's legal entity ("Functional Software, Inc. dba Sentry") or the Sentry parent company — LICENSE copyright notices, PR/issue templates, and docs footer as applicable.

## Out of scope
Legitimate Sentry-product references (the error-monitoring SDK, the Sentry login provider, the "Sentry plan" billing tier, and Sentry-the-customer) are **not** ownership branding and are left unchanged.

## Test plan
- [ ] N/A — license / template / footer text only
